### PR TITLE
Center progress text in CircleProgressView

### DIFF
--- a/MaterialProgressView-master/library/src/main/java/com/moos/library/CircleProgressView.java
+++ b/MaterialProgressView-master/library/src/main/java/com/moos/library/CircleProgressView.java
@@ -337,8 +337,10 @@ public class CircleProgressView extends View {
             mTextPaint.setColor(mProgressTextColor);
             mTextPaint.setTextAlign(Paint.Align.CENTER);
 
-            String progressText = ((int) moveProgress)+ "%";
-            canvas.drawText(progressText, (getWidth() - getPaddingLeft())/2 , (getHeight() - getPaddingTop())/2, mTextPaint);
+            String progressText = ((int) moveProgress) + "%";
+            float x = (getWidth() + getPaddingLeft() - getPaddingRight()) / 2;
+            float y = (getHeight() + getPaddingTop() - getPaddingBottom() - (mTextPaint.descent() + mTextPaint.ascent())) / 2;
+            canvas.drawText(progressText, x , y, mTextPaint);
 
         }
 


### PR DESCRIPTION
I noticed that the progress text wasn't centered in the CircleProgressView.

Before:
![image](https://user-images.githubusercontent.com/22182973/44489299-22a66400-a629-11e8-8177-4f5a6afbaa49.png)

After: 
![image](https://user-images.githubusercontent.com/22182973/44489326-35209d80-a629-11e8-9ae8-5371751d50a2.png)