### PR TITLE
Use Proguard to remove Log.e calls

### DIFF
--- a/MaterialProgressView-master/library/proguard-rules.pro
+++ b/MaterialProgressView-master/library/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-assumenosideeffects class android.util.Log {
+  public static *** e(...);
+}


### PR DESCRIPTION
Unnecessary Log.e calls appears too often. This pull request make use of ProGuard to remove those calls.

Fix #6